### PR TITLE
Use README as site index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 title: JaimeCamachoDev Wiki
 description: Documentación personal y técnica
 theme: minima
+plugins:
+  - jekyll-readme-index


### PR DESCRIPTION
## Summary
- activate `jekyll-readme-index` to make the README the landing page

## Testing
- `bundler --version`
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f3c1252a88326ae907e8b1afc78e2